### PR TITLE
Adds uid to `PresentTag`

### DIFF
--- a/LegoDimensions/LegoPortal.cs
+++ b/LegoDimensions/LegoPortal.cs
@@ -471,7 +471,7 @@ namespace LegoDimensions
 
                                 if (legoTag == null)
                                 {
-                                    _presentTags.Add(new PresentTag((Pad)pad, tadType, padIndex));
+                                    _presentTags.Add(new PresentTag((Pad)pad, tadType, padIndex, uuid));
                                     legoTag = new PadTag() { Pad = (Pad)pad, TagIndex = padIndex, Present = present, CardUid = uuid, TagType = tadType };
                                     _padTag.Add(legoTag);
 
@@ -589,7 +589,9 @@ namespace LegoDimensions
                                 _presentTags.Clear();
                                 for (int i = 0; i < message.Payload.Length / 2; i++)
                                 {
-                                    PresentTag presentTag = new PresentTag((Pad)(message.Payload[i * 2] >> 4), (TagType)message.Payload[i * 2 + 1], (byte)(message.Payload[i * 2] & 0xF));
+                                    var index = (byte)(message.Payload[i * 2] & 0xF);
+                                    var uid = _padTag.FirstOrDefault(x => x.TagIndex == index)?.CardUid ?? Array.Empty<byte>();
+                                    PresentTag presentTag = new PresentTag((Pad)(message.Payload[i * 2] >> 4), (TagType)message.Payload[i * 2 + 1], index, uid);
                                     _presentTags.Add(presentTag);
                                 }
 

--- a/LegoDimensions/Tag/PresentTag.cs
+++ b/LegoDimensions/Tag/PresentTag.cs
@@ -16,11 +16,13 @@ namespace LegoDimensions.Portal
         /// <param name="pad">The pad the tag is on.</param>
         /// <param name="tagType">The type or tag, normal or uninitialized.</param>
         /// <param name="index">The index of the tag on the portal.</param>
-        public PresentTag(Pad pad, TagType tagType, byte index)
+        /// <param name="cardUid">The 7 bytes card UID.</param>
+        public PresentTag(Pad pad, TagType tagType, byte index, byte[] cardUid)
         {
             Pad = pad;
             TagType = tagType;
             Index = index;
+            CardUid = cardUid;
         }
 
         /// <summary>
@@ -37,6 +39,11 @@ namespace LegoDimensions.Portal
         /// Gets or sets the index of the tag on the portal.
         /// </summary>
         public byte Index { get; set; }
+
+        /// <summary>
+        /// Gets or sets the 7 bytes card UID.
+        /// </summary>
+        public byte[] CardUid { get; set; }
     }
 }
 

--- a/TestLegoDimensions/Program.cs
+++ b/TestLegoDimensions/Program.cs
@@ -134,7 +134,7 @@ void TestListTags()
     var tagList = portal.ListTags();
     foreach (var tag in tagList)
     {
-        Console.WriteLine($"Pad: {tag.Pad}, Index: {tag.Index}, Type: {tag.TagType}");
+        Console.WriteLine($"Pad: {tag.Pad}, Index: {tag.Index}, UID: {BitConverter.ToString(tag.CardUid)}, Type: {tag.TagType}");
     }
 }
 


### PR DESCRIPTION
I could not test the code in line 593-594
I am not sure if my changes are needed there.

https://github.com/TheBlubb14/LegoDimensions/blob/main/LegoDimensions/LegoPortal.cs#L593

```cs
Array.Copy(message.Payload, i * 2 + 4, uid, 0, uid.Length);
PresentTag presentTag = new PresentTag((Pad)(message.Payload[i * 2] >> 4), (TagType)message.Payload[i * 2 + 1], (byte)(message.Payload[i * 2] & 0xF), uid);
```