### PR TITLE
Adding docs for Xbox 360

### DIFF
--- a/LegoDimensionsProtocol.md
+++ b/LegoDimensionsProtocol.md
@@ -5,10 +5,14 @@ This document explains the communication protocol between the portal and the mac
 This protocol applies directly to the non-Xbox portals. The Xbox One portal carries
 the same 32-byte messages inside Xbox GIP; see the dedicated
 [Xbox One portal protocol](XboxPortalProtocol.md) for its USB transport and required
-initialization order.
+initialization order. The Xbox 360 portal carries the same 32-byte messages inside a
+simpler 2-byte-prefix wrapper; see the dedicated
+[Xbox 360 portal protocol](Xbox360PortalProtocol.md) for its USB transport and
+concurrency requirements.
 
 The non-Xbox portal vendor ID is `0x0E6F` and its product ID is `0x0241`. The Xbox
 One portal uses product ID `0x0141` and requires the additional GIP transport layer.
+The Xbox 360 portal uses vendor ID `0x24C6` and product ID `0xFA01`.
 
 ## Generalities
 

--- a/README.md
+++ b/README.md
@@ -19,11 +19,11 @@ Use this project to:
 * Set, flash, and fade each portal pad independently.
 * Read and write compatible NFC tags with the portal or a PN532 reader.
 * Build automations using the documented [Lego Dimensions protocol](LegoDimensionsProtocol.md).
-* Explore the separately documented [Xbox One portal protocol](XboxPortalProtocol.md).
+* Explore the separately documented [Xbox One portal protocol](XboxPortalProtocol.md) and
+  [Xbox 360 portal protocol](Xbox360PortalProtocol.md).
 
 > [!NOTE]
-> The main library supports standard portals and the Xbox One portal. The Xbox 360
-> portal is not yet supported. Some experiments are in progress!
+> The main library supports standard portals, the Xbox One portal, and the Xbox 360 portal.
 
 ## Sponsor this project
 
@@ -33,9 +33,11 @@ French and looking for a community of adult fans of Lego (AFOL)? Join [FreeLUG](
 
 ## Lego Dimensions portal
 
-The implementation supports standard Lego Dimensions portals and the Xbox One
-portal. Xbox One uses a GIP transport layer but exposes the same `LegoPortal` API;
-see the [Xbox One portal protocol](XboxPortalProtocol.md) for details.
+The implementation supports standard Lego Dimensions portals, the Xbox One
+portal, and the Xbox 360 portal. Xbox One uses a GIP transport layer and the
+Xbox 360 uses a simpler 2-byte-prefix wrapper, but both expose the same
+`LegoPortal` API; see the [Xbox One portal protocol](XboxPortalProtocol.md) and
+[Xbox 360 portal protocol](Xbox360PortalProtocol.md) for details.
 
 In this document and in the code, the portal refers to the Lego Dimensions where you place the vehicles and characters.
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ For an Xbox One portal, select the Xbox Gaming Device with hardware ID
 `USB\VID_0E6F&PID_0141` and install WinUSB. The NuGet package includes
 the native libusb runtime used by the library.
 
+For an Xbox 360 portal, select the device with hardware ID
+`USB\VID_24C6&PID_FA01` and install WinUSB the same way.
+
 For Linux users
 
 * Install libusb and libusb1 if not already installed like `sudo apt-get libusb-dev` on a Rapsberry Pi

--- a/Xbox360PortalProtocol.md
+++ b/Xbox360PortalProtocol.md
@@ -1,0 +1,120 @@
+# Xbox 360 Lego Dimensions Portal Protocol
+
+This document describes the protocol used by the Xbox 360 Lego Dimensions portal
+with USB ID `24C6:FA01`. It records behavior verified with real hardware and the
+[`XboxPortalProbe`](XboxPortalProbe/) diagnostic application.
+
+Unlike the [Xbox One portal](XboxPortalProtocol.md), the Xbox 360 portal does not
+use a games-input-protocol transport. It carries the ordinary 32-byte Lego
+Dimensions message inside a fixed 2-byte prefix on top of a 32-byte interrupt
+report:
+
+```text
+USB interrupt transfer
+└── 0B 16 prefix
+    └── 30 bytes of a 32-byte Lego Dimensions message (last 2 bytes dropped)
+```
+
+The embedded message uses the same commands and checksums as non-Xbox portals.
+See [Lego Dimensions Communication Protocol](LegoDimensionsProtocol.md) for the
+command details and tag data format shared by all portals.
+
+## Status and scope
+
+The following behavior has been verified on an Xbox 360 portal with product ID
+`0xFA01`:
+
+- Device discovery and endpoint access through WinUSB/libusb, without claiming
+  the XSM3 security interface.
+- Wake, tag events, tag reads, pad colors, and tag listing over the wrapped
+  32-byte LEGO protocol.
+- Reliable continuous background reads while commands are sent from another
+  thread (see [Concurrency](#concurrency) below).
+
+The main `LegoPortal` class detects vendor/product ID `24C6:FA01`, performs the
+initialization sequence below, and wraps or unwraps the frame automatically.
+Applications use the same public API as they use for a standard portal.
+
+## USB transport
+
+| Property | Value |
+| --- | --- |
+| Vendor ID | `0x24C6` |
+| Product ID | `0xFA01` |
+| Interface | First interface, normally `0` |
+| Host-to-portal endpoint | `0x01` |
+| Portal-to-host endpoint | `0x81` |
+| Tested Windows driver | WinUSB |
+
+The host should perform these USB steps:
+
+1. Open the device.
+2. On Windows, skip resetting/selecting the USB configuration; select it on other
+   platforms. This mirrors the reference `toypad.py` implementation, which
+   hardcodes the same platform split.
+3. Claim the first interface only.
+4. Open endpoint `0x81` for reads and endpoint `0x01` for writes.
+
+### No XSM3 binding required
+
+The portal also exposes an XSM3 security interface (interface 3) and identifies
+itself through XSM3 request `81` with security VID/PID `24C6:5000`. Unlike an
+Xbox 360 game controller, **this portal replies to LEGO application commands
+(wake, colors, tag reads, tag events) without ever completing XSM3
+authentication.** The main library never claims interface 3.
+
+`XboxPortalProbe` still implements the XSM3 exchange (identity, challenge,
+status, phase-one response, verify, acknowledgement) as a diagnostic path,
+because the host-side cryptography needed independent verification against the
+published Microsoft-controller transaction. That exchange is not part of normal
+operation; see the probe's [README](XboxPortalProbe/README.md#xbox-360-investigation)
+for details.
+
+## Frame wrapper
+
+Every interrupt report sent or received is 32 bytes:
+
+| b0 | b1 | b2 -> b31 |
+| --- | --- | --- |
+| `0x0B` | `0x16` | First 30 bytes of the standard 32-byte Lego Dimensions frame |
+
+The prefix bytes are fixed; only the remaining 30 bytes carry the standard
+message (checksum, message type, command, payload). Because a standard frame is
+32 bytes and only 30 fit after the prefix, its last 2 bytes (always zero padding
+on outgoing frames) are not transmitted and are reconstructed as zero on receive.
+
+An earlier capture had misread the second prefix byte as `0x14`; the corrected
+`0x16` value is confirmed by the
+[dopheideb/LEGODimensions](https://github.com/dopheideb/LEGODimensions) toy pad
+firmware extraction.
+
+## Wake
+
+The wake command uses LEGO message ID `0x00` explicitly, rather than the
+auto-assigned ID used for every other command. This matches `toypad.py`, which
+hardcodes `message_id=0` for wake on this portal. The auto assigned ID should work as well.
+
+## Concurrency
+
+The portal's interrupt endpoints do not tolerate two things a standard or Xbox
+One portal tolerates:
+
+- **Concurrent read and write.** A background thread continuously issuing
+  `libusb_interrupt_transfer` reads while another thread concurrently issues a
+  write on the same device handle silently loses replies. This was confirmed to
+  be a host-side (libusb/Windows backend) limitation, not a portal-side gate or
+  a LibUsbDotNet-specific defect, by comparing raw sequential calls against a
+  hybrid background-read-plus-write shape using direct P/Invoke to
+  `libusb-1.0.dll` (see `XboxPortalProbe`'s `raw-wake-360` / `hybrid-wake-360` /
+  `hybrid-async-wake-360` commands). The main library enforces full-duration
+  mutual exclusion between every read and every write for this portal type.
+- **Two in-flight tracked commands.** Sending a second tracked request/reply
+  command (e.g. a `Read`) before the first one's reply has arrived appears to
+  corrupt or drop one of the two replies, even though each carries a distinct
+  message ID. The main library serializes tracked commands for this portal type
+  so only one request/reply cycle is outstanding at a time, and skips its
+  internal auto-read-on-tag-placement rather than blocking if a command is
+  already in flight.
+
+Both constraints are specific to this portal; standard and Xbox One portals are
+unaffected.

--- a/XboxPortalProbe/README.md
+++ b/XboxPortalProbe/README.md
@@ -10,9 +10,10 @@ The complete transport and initialization sequence is documented in the
 
 ## Windows setup
 
-The standard Microsoft driver identifies the portal as an Xbox Gaming Device and
-does not expose it to libusb. Use Zadig to replace that device's driver with
-WinUSB for testing. Select the device with hardware ID `USB\VID_0E6F&PID_0141`.
+The standard Microsoft driver identifies either portal as an Xbox Gaming Device
+and does not expose it to libusb. Use Zadig to replace that device's driver with
+WinUSB for testing. Select the device with hardware ID `USB\VID_0E6F&PID_0141`
+for the Xbox One portal, or `USB\VID_24C6&PID_FA01` for the Xbox 360 portal.
 Changing the driver may prevent the portal from working with an Xbox until the
 Microsoft driver is restored.
 

--- a/XboxPortalProbe/README.md
+++ b/XboxPortalProbe/README.md
@@ -1,10 +1,12 @@
 # Xbox portal probe
 
 This diagnostic console targets the Xbox One Lego Dimensions portal at USB ID
-`0E6F:0141`. The main library now supports this portal directly; this application
-remains useful for raw protocol investigation and command testing.
+`0E6F:0141` and the Xbox 360 Lego Dimensions portal at USB ID `24C6:FA01`. The
+main library now supports both portals directly; this application remains
+useful for raw protocol investigation and command testing.
 The complete transport and initialization sequence is documented in the
-[Xbox One portal protocol](../XboxPortalProtocol.md).
+[Xbox One portal protocol](../XboxPortalProtocol.md) and the
+[Xbox 360 portal protocol](../Xbox360PortalProtocol.md).
 
 ## Windows setup
 
@@ -87,6 +89,8 @@ in particular, `test-write` never supplies default bytes.
 If no Xbox One portal is present, the probe falls back to the Xbox 360 portal
 at `24C6:FA01`. The main library (`LegoDimensions.LegoPortal`) now supports this
 portal directly too; this mode remains useful for raw protocol investigation.
+See the [Xbox 360 portal protocol](../Xbox360PortalProtocol.md) for the verified
+frame format and concurrency requirements.
 
 The probe claims interface 0 for interrupt endpoints `81/01`. Interface 3
 (XSM3 security) is never claimed for normal operation - the toypad replies to

--- a/XboxPortalProtocol.md
+++ b/XboxPortalProtocol.md
@@ -39,8 +39,9 @@ sequence below, and wraps or unwraps GIP automatically. Applications can use the
 same public API as they use for a standard portal.
 
 This document does not describe the Xbox 360 portal or claim that its transport is
-the same. Replacing the Windows driver may prevent the portal from working with an
-Xbox until the Microsoft driver is restored.
+the same; see the dedicated [Xbox 360 portal protocol](Xbox360PortalProtocol.md).
+Replacing the Windows driver may prevent the portal from working with an Xbox
+until the Microsoft driver is restored.
 
 ## USB transport
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added documentation for Xbox 360 LEGO Dimensions portal support, including USB identification, message framing, initialization, wake behavior, and command handling.
  * Documented Xbox 360 communication and concurrency requirements.
  * Updated README files to list Xbox 360 alongside Xbox One portals, with Windows WinUSB setup guidance.
  * Added protocol references and clarified supported hardware identifiers and driver installation instructions.
  * Improved protocol documentation links, warnings, and formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->